### PR TITLE
Creating Yuku the package for Scienti open Data

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, '3.10', 3.11]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --ignore=C901 --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --ignore=C901 --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        python setup.py develop --user
+        pytest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,31 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload --repository pypi dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include yuku/ *.py
+recursive-include yuku/ *.*

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ We are downloading two datasets
 
 Additionally we are scrapping cvlac profiles of researches from scienti website.
 
+All the data is saved in MongoDB.
+
 # Installation
 
 ## Dependencies
@@ -130,6 +132,24 @@ The gruplac downlaod dont supports checkpoints, but it support pagination, the c
 `
 yuku_run --download_cvlac bqtm-4y2h
 `
+
+# Yuku Results
+
+By default the data is saved in the database yuku with the next collections:
+```
+yuku> show collections
+cvlac_data
+cvlac_dataset_info
+cvlac_stage
+gruplac_data
+gruplac_dataset_info
+```
+
+* cvlav_data: is the dataset for cvlac, downloaded from socrata (www.datos.gov.co)
+* cvlac_dataset_info: information about the dataset, this explains the fields and provide metadata about the cvlac dataset.
+* cvlac_stage: this is the collection for the scrapped data from cvlac (minciencias web site).
+* gruplac_data: is the dataset for gruplac, downloaded from socrata (www.datos.gov.co)
+* gruplac_dataset_info: information about the dataset, this explains the fields and provide metadata about the gruplac dataset.
 
 # License
 BSD-3-Clause License 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,100 @@ mongodb mongod --dbpath $HOME/data/db/
 `pip install yuku`
 
 # Usage
+## Searching for required datasets IDs
+Example to get dataset id for researchers
 
+`
+yuku_run --search "Investigadores Reconocidos por convocatoria" --search_limit 3
+`
+
+Output is like next example, where you can take the required dateset ID ex: bqtm-4y2h
+
+```
+WARNING:root:Requests made without an app_token will be subject to strict throttling limits.
+name:  Investigadores Reconocidos por convocatoria
+id:  bqtm-4y2h
+description:  Investigadores reconocidos por convocatoria a través de la Plataforma ScienTI - Colombia.
+attribution:  Ministerio de Ciencia y Tecnología e Innovación
+attribution_link:  https://www.minciencias.gov.co
+type:  dataset
+updatedAt:  2022-09-25T05:33:58.000Z
+createdAt:  2021-07-23T20:17:20.000Z
+
+name:  Investigadores Reconocidos por convocatoria 2019
+id:  izwp-q8gg
+description:  Investigadores reconocidos por convocatoria a través de la Plataforma ScienTI - Colombia.
+attribution:  Ministerio de Ciencia y Tecnología e Innovación
+attribution_link:  https://www.minciencias.gov.co
+type:  chart
+updatedAt:  2022-09-25T05:35:54.000Z
+createdAt:  2021-07-27T04:57:43.000Z
+
+name:  Investigadores Reconocidos por convocatoria 2021
+id:  gzff-pwwc
+description:  Investigadores reconocidos por convocatoria a través de la Plataforma ScienTI - Colombia.
+attribution:  Ministerio de Ciencia y Tecnología e Innovación
+attribution_link:  https://www.minciencias.gov.co
+type:  chart
+updatedAt:  2022-09-25T05:43:29.000Z
+createdAt:  2022-09-25T05:40:12.000Z
+
+```
+
+Example to get dataset id for groups, in this example I took ID ex: 33dq-ab5a
+
+`
+yuku_run --search "Producción Grupos Investigación" --search_limit 3
+`
+
+Output:
+
+```
+WARNING:root:Requests made without an app_token will be subject to strict throttling limits.
+name:  Producción Grupos Investigación
+id:  33dq-ab5a
+description:  Producción revisada y evaluada con la cual participó el grupo de investigación de acuerdo con la ventana de observación para la convocatoria
+attribution:  Ministerio de Ciencia, Tecnología e Innovación
+attribution_link:  https://www.minciencias.gov.co
+type:  dataset
+updatedAt:  2022-10-13T18:28:46.000Z
+createdAt:  2021-07-26T07:14:22.000Z
+
+name:  Producción Grupos Investigación 2019
+id:  cpuy-2qxm
+description:  Producción revisada y evaluada con la cual participó el grupo de investigación de acuerdo con la ventana de observación para la convocatoria
+attribution:  Ministerio de Ciencia, Tecnología e Innovación
+attribution_link:  https://www.minciencias.gov.co
+type:  chart
+updatedAt:  2022-10-13T18:23:02.000Z
+createdAt:  2021-07-27T02:20:39.000Z
+
+name:  Producción Grupos Investigación 2021
+id:  bs69-ze7w
+description:  Producción revisada y evaluada con la cual participó el grupo de investigación de acuerdo con la ventana de observación para la convocatoria
+attribution:  Ministerio de Ciencia, Tecnología e Innovación
+attribution_link:  https://www.minciencias.gov.co
+type:  chart
+updatedAt:  2022-10-13T17:48:49.000Z
+createdAt:  2022-10-13T17:41:10.000Z
+
+```
+
+## Download CVLAC data
+
+The cvlac downlaod supports checkpoints, it takes long time to download the profiles, about 9 hours.
+
+`
+yuku_run --download_cvlac bqtm-4y2h
+`
+
+## Download GRUPLAC data
+
+The gruplac downlaod dont supports checkpoints, but it support pagination, the cache is saved in the collection gruplac_data_cache, but it is eventually removed if the execution fails.  This run takes about 1 hour.
+
+`
+yuku_run --download_cvlac bqtm-4y2h
+`
 
 # License
 BSD-3-Clause License 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
+<center><img src="https://raw.githubusercontent.com/colav/colav.github.io/master/img/Logo.png"/></center>
+
 # Yuku
-Open Data Scienti / Yuku, god of rain  Yaqui mythology in northern Mexico.
+Scienti Open Data / Yuku, god of rain in Yaqui mythology in northern Mexico.
+
+
+# Description
+This package allows to download Scienti open data using socrata api service.
+We are downloading two datasets 
+* "Investigadores Reconocidos por convocatoria"
+* "Producción Grupos Investigación"
+
+Additionally we are scrapping cvlac profiles of researches from scienti website.
+
+# Installation
+
+## Dependencies
+* Install MongoDB
+    * Debian based system: `apt-get install mongodb`
+    * Redhat based system instructions [here](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-red-hat/)
+    * Conda: `conda install mongodb mongo-tools`
+
+NOTE:
+
+To start mongodb server on conda please run the next steps
+
+`
+mkdir -p $HOME/data/db 
+`
+
+`
+mongodb mongod --dbpath $HOME/data/db/
+`
+
+## Package
+`pip install yuku`
+
+# Usage
+
+
+# License
+BSD-3-Clause License 
+
+# Links
+http://colav.udea.edu.co/
+
+
+

--- a/bin/yuku_run
+++ b/bin/yuku_run
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+from yuku.Yuku import Yuku
+
+import argparse
+import faulthandler
+faulthandler.enable()
+
+parser = argparse.ArgumentParser(description='Yuku Scienti')
+parser.add_argument('--mongo_dburi', type=str,
+                    default='mongodb://localhost:27017/', help='uri for MongoDb database')
+parser.add_argument('--mongo_dbname', type=str,
+                    default="yuku_scienti", help='MongoDb name to save the data.')
+parser.add_argument('--socrata_endpoint', type=str,
+                    default="www.datos.gov.co", help='Endpoint for minciencias in socrata server: default www.datos.gov.co')
+parser.add_argument('--search', type=str,
+                    help='Method to search in the socrata in the endpoint "www.datos.gov.co" \
+                          using elastic search, return number of elements indicated in --search_limit, by default it is 5')
+parser.add_argument('--search_limit', type=int, default=5,
+                    help='Method to search in the socrata in the endpoint "www.datos.gov.co" \
+                          using elastic search, return number of elements indicated in --search_limit, by default it is 5')
+parser.add_argument('--drop_mongodb', action='store_true',
+                    help='delete the database, use it with careful, deletes everything!')
+
+
+if __name__ == '__main__':
+    args = parser.parse_args()
+    yuku = Yuku(args.mongo_dbname, args.mongo_dburi,
+                     args.socrata_endpoint)
+    if args.search is not None:
+        yuku.search(args.search, args.search_limit)

--- a/bin/yuku_run
+++ b/bin/yuku_run
@@ -20,11 +20,21 @@ parser.add_argument('--search_limit', type=int, default=5,
                           using elastic search, return number of elements indicated in --search_limit, by default it is 5')
 parser.add_argument('--drop_mongodb', action='store_true',
                     help='delete the database, use it with careful, deletes everything!')
+parser.add_argument('--download_cvlac', type=str,
+                    help='Download cvlac data for given dataset id and perform scrapping from public profiles in mincienias')
+parser.add_argument('--download_gruplac', type=str,
+                    help='Download gruplac data for given dataset id')
 
 
 if __name__ == '__main__':
     args = parser.parse_args()
     yuku = Yuku(args.mongo_dbname, args.mongo_dburi,
-                     args.socrata_endpoint)
+                args.socrata_endpoint)
     if args.search is not None:
         yuku.search(args.search, args.search_limit)
+    
+    if args.download_cvlac is not None:
+        yuku.download_cvlac(args.download_cvlac)
+
+    if args.download_gruplac is not None:
+        yuku.download_gruplac(args.download_gruplac)

--- a/bin/yuku_run
+++ b/bin/yuku_run
@@ -9,7 +9,7 @@ parser = argparse.ArgumentParser(description='Yuku Scienti')
 parser.add_argument('--mongo_dburi', type=str,
                     default='mongodb://localhost:27017/', help='uri for MongoDb database')
 parser.add_argument('--mongo_dbname', type=str,
-                    default="yuku_scienti", help='MongoDb name to save the data.')
+                    default="yuku", help='MongoDb name to save the data.')
 parser.add_argument('--socrata_endpoint', type=str,
                     default="www.datos.gov.co", help='Endpoint for minciencias in socrata server: default www.datos.gov.co')
 parser.add_argument('--search', type=str,
@@ -32,7 +32,7 @@ if __name__ == '__main__':
                 args.socrata_endpoint)
     if args.search is not None:
         yuku.search(args.search, args.search_limit)
-    
+
     if args.download_cvlac is not None:
         yuku.download_cvlac(args.download_cvlac)
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+# Copyright (c) Colav.
+# Distributed under the terms of the Modified BSD License.
+
+# -----------------------------------------------------------------------------
+# Minimal Python version sanity check (from IPython)
+# -----------------------------------------------------------------------------
+
+# See https://stackoverflow.com/a/26737258/2268280
+# sudo pip3 install twine
+# python3 setup.py sdist bdist_wheel
+# twine upload dist/*
+# For test purposes
+# twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+from __future__ import print_function
+from setuptools import setup, find_packages
+
+import os
+import sys
+import codecs
+
+
+v = sys.version_info
+
+
+def read(rel_path):
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fp:
+        return fp.read()
+
+
+def get_version(rel_path):
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    else:
+        raise RuntimeError("Unable to find version string.")
+
+
+shell = False
+if os.name in ('nt', 'dos'):
+    shell = True
+    warning = "WARNING: Windows is not officially supported"
+    print(warning, file=sys.stderr)
+
+
+def main():
+    setup(
+        # Application name:
+        name="Yuku",
+
+        # Version number (initial):
+        version=get_version('yuku/_version.py'),
+
+        # Application author details:
+        author="Colav",
+        author_email="colav@udea.edu.co",
+
+        # Packages
+        packages=find_packages(exclude=['tests']),
+
+        # Include additional files into the package
+        include_package_data=True,
+
+        # Details
+        url="https://github.com/colav/Yuku",
+        scripts=['bin/yuku_run'],
+        #
+        license="BSD",
+
+        description="Scienti Open Data",
+
+        long_description=open("README.md").read(),
+
+        long_description_content_type="text/markdown",
+
+        # Dependent packages (distributions)
+        install_requires=[
+            'pymongo>=3.10.1',
+            'pandas',
+            'requests>=2.22.0',
+            'sodapy',
+            'beautifulsoup4'
+        ],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/yuku/Yuku.py
+++ b/yuku/Yuku.py
@@ -6,7 +6,6 @@ from sodapy import Socrata
 from bs4 import BeautifulSoup
 import time
 import urllib3
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class Yuku:
@@ -23,6 +22,7 @@ class Yuku:
         self.mlient = MongoClient(mongodb_uri)
         self.db = self.mlient[mongo_db]
         self.socrata_endpoint = socrata_endpoint
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     def download_cvlac(self, dataset_id: str):
         """
@@ -159,7 +159,7 @@ class Yuku:
             print(f"INFO: downloaded {counter}")
             self.db["gruplac_data_cache"].rename("gruplac_data")
 
-    def search_dataset(self, q: str, limit: int = 5):
+    def search(self, q: str, limit: int = 5):
         """
         Method to search datasets in socrata for the endpoint www.datos.gov.co
 

--- a/yuku/Yuku.py
+++ b/yuku/Yuku.py
@@ -1,0 +1,190 @@
+import requests
+import re
+import pandas as pd
+from pymongo import MongoClient
+from sodapy import Socrata
+from bs4 import BeautifulSoup
+import time
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+
+class Yuku:
+    def __init__(self, mongo_db: str = "yuku", mongodb_uri: str = "mongodb://localhost:27017/", socrata_endpoint: str = "www.datos.gov.co"):
+        """
+        Contructor for Yuku, we only support open datasets, credentials are not supported.
+
+        Parameters:
+        ------------
+        socrata_endpoint:str
+            endpoint for socrata, default "www.datos.gov.co"
+        """
+        self.client = Socrata("www.datos.gov.co", None, timeout=120)
+        self.mlient = MongoClient(mongodb_uri)
+        self.db = self.mlient[mongo_db]
+        self.socrata_endpoint = socrata_endpoint
+
+    def download_cvlac(self, dataset_id: str):
+        """
+        Method to download cvlav information.
+        This can take long time, but if something goes wrong we support checkpoint.
+
+        Parameters:
+        ------------
+        dataset_id:str
+            id for dataset in socrata ex: bqtm-4y2h
+        """
+        scienti_url = 'https://scienti.minciencias.gov.co/cvlac/visualizador/generarCurriculoCv.do?cod_rh='
+        if "cvlac_dataset_info" in self.db.list_collection_names():
+            print("WARNING: cvlac_dataset_info already in the database, it will be not downloaded again, drop the database if you want start over.")
+        else:
+            print(f"INFO: downloading dataset metadata from id {dataset_id}")
+            dataset_info = self.client.get_metadata(dataset_id)
+            self.db["cvlac_dataset_info"].insert_one(dataset_info)
+        if "cvlac_data" in self.db.list_collection_names():
+            print("WARNING: cvlac_data already in the database, it will be not downloaded again, drop the database if you want start over.")
+        else:
+            data = self.client.get_all(dataset_id)
+            data = list(data)
+            self.db["cvlac_data"].insert_many(data)
+        cod_rh_data = self.db["cvlac_data"].distinct("id_persona_pr")
+        cod_rh_stage = self.db["cvlac_stage"].distinct("id_persona_pr")
+        # computing the remaining ids for scrapping
+        cod_rh = set(cod_rh_data) - set(cod_rh_stage)
+        cod_rh = list(cod_rh)
+        print(f"INFO: found {len(cod_rh_data)} records in data\n      found {len(cod_rh_stage)} in stage\n      found {len(cod_rh)} remain records to download.")
+
+        for cvlac in cod_rh:
+            url = f'{scienti_url}{cvlac}'
+
+            dd = {'id_persona_pr': cvlac}
+
+            try:
+                r = requests.get(url, verify=False)
+            except Exception:
+                continue
+
+            if not r.text:
+                continue
+
+            soup = BeautifulSoup(r.text, 'lxml')  # Parse the HTML as a string
+            tables = soup.find_all('table')
+
+            # 1: Full names
+            if len(tables) > 2:
+                t = tables[1]
+            else:
+                dd['nombre'] = ''
+                continue
+
+            tr = pd.read_html(t.decode())[0].to_dict(orient='records')
+
+            for d in tr:
+                if d and isinstance(d.get(0), str) and isinstance(d.get(1), str):
+                    dd[d.get(0)] = d.get(1).replace('\xa0', ' ')
+                else:
+                    continue
+
+            # 2. Academic Social Networks  and authors Ids
+            t = tables[2]
+
+            # 2.a) Academic Social Networks (Google Scholar)
+            next = 2
+            try:
+                ids = t.find_all('h3')[0].text
+            except Exception:
+                ids = ''
+            if ids == 'Redes sociales académicas':
+                next = 3
+                ll = t.find_all('a')
+                for x in ll:
+                    try:
+                        dd[x.text.split(' (')[0]] = x['href']
+                    except Exception:
+                        continue
+            # 2.b) authors Ids (ORCID, Scopus, ...)
+            try:
+                t = tables[next]
+            except Exception:
+                continue
+
+            try:
+                ids = t.find_all('h3')[0].text
+            except Exception:
+                ids = ''
+            if ids == 'Identificadores de autor':
+                ll = t.find_all('a')
+                for x in ll:
+                    try:
+                        dd[re.search('\(([\w]+)\)', x.text).groups()[0]] = x['href']# noqa
+                    except Exception:
+                        continue
+            self.db["cvlac_stage"].insert_one(dd)
+            time.sleep(0.3)
+
+    def download_gruplac(self, dataset_id: str):
+        """
+        Method to download gruplac information.
+        Unfortunately we dont have support for checkpoint in this method.
+
+        Parameters:
+        ------------
+        dataset_id:str
+            id for dataset in socrata ex: 33dq-ab5a
+        """
+        if "gruplac_dataset_info" in self.db.list_collection_names():
+            print("WARNING: cvlac_dataset_info already in the database, it will be not downloaded again, drop the database if you want start over.")
+        else:
+            print(f"INFO: downloading dataset metadata from id {dataset_id}")
+            dataset_info = self.client.get_metadata(dataset_id)
+            self.db["gruplac_dataset_info"].insert_one(dataset_info)
+        if "gruplac_data" in self.db.list_collection_names():
+            print("WARNING: gruplac_data already in the database, it will be not downloaded again, drop the database if you want start over.")
+        else:
+            dataset = self.db["gruplac_dataset_info"].find_one()
+            self.db["gruplac_data_cache"].drop()
+            cursor = self.client.get_all(dataset_id)
+            data = []
+            count = int(dataset['columns'][0]['cachedContents']['count'])
+            print(f"INFO: Total groups found = {count}.")
+            counter = 0
+            for i in cursor:
+                if counter % 20000 == 0:
+                    print(f"INFO: downloaded {counter}")
+                    self.db["gruplac_data_cache"].insert_many(data)
+                    data = []
+                data.append(i)
+                counter += 1
+            self.db["gruplac_data_cache"].insert_many(data)
+            print(f"INFO: downloaded {counter}")
+            self.db["gruplac_data_cache"].rename("gruplac_data")
+
+    def search_dataset(self, q: str, limit: int = 5):
+        """
+        Method to search datasets in socrata for the endpoint www.datos.gov.co
+
+        examples:
+        * q="Investigadores Reconocidos por convocatoria"
+        * q="Producción Grupos Investigación"
+
+        Parameters:
+        -----------
+        q:str
+            Elastic search query, results of datasets are besed on similarity
+        limit:int
+            number of results to display, default firts 5 elements.
+        """
+        datasets = self.client.datasets(
+            q=q, public=True)  # busca en elastic search con query "q"
+        for dataset in datasets[0:limit]:
+            print("name: ", dataset["resource"]["name"])
+            print("id: ", dataset["resource"]["id"])
+            print("description: ", dataset["resource"]["description"])
+            print("attribution: ", dataset["resource"]["attribution"])
+            print("attribution_link: ",
+                  dataset["resource"]["attribution_link"])
+            print("type: ", dataset["resource"]["type"])
+            print("updatedAt: ", dataset["resource"]["updatedAt"])
+            print("createdAt: ", dataset["resource"]["createdAt"])
+            print('\n\n')
+        return datasets[0:limit]

--- a/yuku/_version.py
+++ b/yuku/_version.py
@@ -1,0 +1,5 @@
+# flake8: noqa
+__version__ = '0.0.1-alpha'
+
+def get_version():
+    return __version__


### PR DESCRIPTION
This is the package for scienti open data

Scienti is based on Socrata, which is a service creates endpoints for data,
Yuku was implemented using sodapy package that supports socrata apis, take a look on socrata doc at 
https://dev.socrata.com/foundry/www.datos.gov.co/33dq-ab5a
in the Code Snippets for python

This package supports:
*  Download the dataset for CVLAC from www.datos.gov.co
    *  With the ids of the dataset (COD_RH) perform scrapping to get researchers' information
    * Support checkpoint, the scrapper can continue without loose information if something goes wrong
*  Download the dataset for GRUPLAC
    * It doesn´t support checkpoint
    * Supports pagination
* It has a method to perform searches in elastic search to find ids, take a look in the readme.
* Documentation
* Examples
* github actions
   * to check code with flake8
   * to create a package for pypi